### PR TITLE
General Refactor

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,1 +1,3 @@
 REDIS_URL="redis://rediswoohoo:abc123@example.com:12345/"
+RACK_ENV="development"
+QUEUE="swift_review"

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ gem "dotenv"
 gem "awesome_print"
 
 group :test, :development do
-  gem "byebug"
   gem "rspec"
+  gem "pry"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     awesome_print (1.6.1)
-    byebug (3.2.0)
-      columnize (~> 0.8)
-      debugger-linecache (~> 1.2)
-    columnize (0.9.0)
-    debugger-linecache (1.2.0)
+    coderay (1.1.0)
     diff-lcs (1.2.5)
     dotenv (2.0.1)
+    method_source (0.8.2)
     mono_logger (1.1.0)
     multi_json (1.11.0)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.6.0)
     rack-protection (1.5.3)
       rack
@@ -41,6 +42,7 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
+    slop (3.6.0)
     tilt (1.4.1)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -50,8 +52,8 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print
-  byebug
   dotenv
+  pry
   rake
   resque
   rspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-$:.unshift(".", "lib")
-Dir.glob("lib/**/*.rb").each { |file| require file }
+require "./config/environment"
 
-ENV["RACK_ENV"] ||= "development"
 Dir.glob("lib/tasks/**/*.rake").each { |file| load file }

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,0 +1,6 @@
+$LOAD_PATH.unshift(".", "lib")
+
+require "config/initializers/dotenv"
+
+Dir.glob("config/initializers/**/*.rb").each { |file| require file }
+Dir.glob("lib/**/*.rb").each { |file| require file }

--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -1,0 +1,2 @@
+require "dotenv"
+Dotenv.load

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,3 +1,6 @@
+require "uri"
+require "resque"
+
 if ENV["REDIS_URL"]
   uri = URI.parse(ENV["REDIS_URL"])
   REDIS = Redis.new(

--- a/lib/jobs/swift_review_job.rb
+++ b/lib/jobs/swift_review_job.rb
@@ -1,9 +1,10 @@
 require "resque"
 require "awesome_print"
 
-require "swift_lint"
-require "swift_lint/runner"
 require "jobs/completed_file_review_job"
+require "swift_lint"
+require "swift_lint/file"
+require "swift_lint/runner"
 
 class SwiftReviewJob
   @queue = :swift_review
@@ -16,27 +17,39 @@ class SwiftReviewJob
     # content
     # config
 
-    violations = violations_for_content(attributes["content"])
+    file = file_for(attributes: attributes)
+    violations = violations_for(file: file)
 
-    Resque.enqueue(
-      CompletedFileReviewJob,
-      filename: attributes.fetch("filename"),
-      commit_sha: attributes.fetch("commit_sha"),
-      pull_request_number: attributes.fetch("pull_request_number"),
-      patch: attributes.fetch("patch"),
-      violations: violations
+    completed_file_review(
+      file: file,
+      attributes: attributes,
+      violations: violations,
     )
   rescue => error
     ap error
     ap error.backtrace
   end
 
-  def self.violations_for_content(content)
-    swift_lint_runner = SwiftLint::Runner.new
-    swift_violations = swift_lint_runner.violations_for(content)
+  def self.completed_file_review(file:, attributes:, violations:)
+    Resque.enqueue(
+      CompletedFileReviewJob,
+      filename: file.name,
+      commit_sha: attributes.fetch("commit_sha"),
+      pull_request_number: attributes.fetch("pull_request_number"),
+      patch: attributes.fetch("patch"),
+      violations: violations,
+    )
+  end
 
-    swift_violations.map do |violation|
-      { line: violation.line_number, message: violation.message }
-    end
+  def self.violations_for(file:)
+    swift_lint_runner = SwiftLint::Runner.new
+    swift_lint_runner.violations_for(file)
+  end
+
+  def self.file_for(attributes:)
+    SwiftLint::File.new(
+      attributes.fetch("filename"),
+      attributes.fetch("content"),
+    )
   end
 end

--- a/lib/swift_lint/file.rb
+++ b/lib/swift_lint/file.rb
@@ -1,0 +1,10 @@
+module SwiftLint
+  class File
+    attr_reader :name, :content
+
+    def initialize(name, content)
+      @name = name
+      @content = content
+    end
+  end
+end

--- a/lib/swift_lint/runner.rb
+++ b/lib/swift_lint/runner.rb
@@ -2,10 +2,10 @@ require "swift_lint/violation"
 
 module SwiftLint
   class Runner
-    def violations_for(content)
-      violation_strings = execute_swiftlint(content).split("\n")
+    def violations_for(file)
+      violation_strings = execute_swiftlint(file.content).split("\n")
       violation_strings.map do |violation_string|
-        Violation.new(violation_string)
+        Violation.new(violation_string).to_hash
       end
     end
 

--- a/lib/swift_lint/violation.rb
+++ b/lib/swift_lint/violation.rb
@@ -7,6 +7,13 @@ module SwiftLint
       @violation = violation_string
     end
 
+    def to_hash
+      {
+        line: line_number,
+        message: message,
+      }
+    end
+
     def line_number
       LINE_NUMBER_REGEX.match(violation)[1].to_i
     end

--- a/lib/tasks/jobs/work.rake
+++ b/lib/tasks/jobs/work.rake
@@ -1,10 +1,4 @@
-require "config/redis"
 require "resque/tasks"
-require "dotenv/tasks"
-
-task "resque:setup" do
-  ENV["QUEUE"] = "swift_review"
-end
 
 desc "Alias for resque:work (To run workers)"
-task "jobs:work" => [:dotenv, "resque:work"]
+task "jobs:work" => ["resque:work"]

--- a/spec/jobs/swift_review_job_spec.rb
+++ b/spec/jobs/swift_review_job_spec.rb
@@ -4,8 +4,10 @@ require "jobs/swift_review_job"
 describe SwiftReviewJob do
   describe ".perform" do
     it "enqueues review job with violations" do
-      allow(Resque).to receive("enqueue")
-      allow_any_instance_of(SwiftLint::Runner).
+      runner = SwiftLint::Runner.new
+      allow(Resque).to receive(:enqueue)
+      allow(SwiftLint::Runner).to receive(:new).and_return(runner)
+      allow(runner).
         to receive(:execute_swiftlint).and_return(swiftlint_response)
 
       SwiftReviewJob.perform(
@@ -13,10 +15,10 @@ describe SwiftReviewJob do
         "commit_sha" => "123abc",
         "pull_request_number" => "123",
         "patch" => "test",
-        "content" => "let number = 1 "
+        "content" => "let number = 1 \n",
       )
 
-      expect(Resque).to have_received("enqueue").with(
+      expect(Resque).to have_received(:enqueue).with(
         CompletedFileReviewJob,
         filename: "test.swift",
         commit_sha: "123abc",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,5 +2,3 @@ $: << File.expand_path(".")
 
 ENV["RACK_ENV"] = "test"
 ENV["REDIS_URL"] = "redis://rediswoohoo:abc123@example.com:12345/"
-
-require "byebug"


### PR DESCRIPTION
Why:

* Clean up some of the initial code

This change addresses the need by:

* Extract some methods in SwiftReviewJob
* Introduce concept of `File`
* Have `Violation#to_hash` return the format Hound wants
  instead of manually mapping elsewhere.