### PR TITLE
Add Sentry for Error tracking

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,3 +1,4 @@
-REDIS_URL="redis://rediswoohoo:abc123@example.com:12345/"
-RACK_ENV="development"
 QUEUE="swift_review"
+RACK_ENV="development"
+REDIS_URL="redis://rediswoohoo:abc123@example.com:12345/"
+SENTRY_DSN="http://public:secret@example.com/project-id"

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,14 @@ source "https://rubygems.org"
 
 ruby "2.2.2"
 
+gem "awesome_print"
+gem "dotenv"
 gem "rake"
 gem "resque"
-gem "dotenv"
-gem "awesome_print"
+gem "resque-sentry"
+gem "sentry-raven"
 
 group :test, :development do
-  gem "rspec"
   gem "pry"
+  gem "rspec"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     awesome_print (1.6.1)
+    certifi (2015.08.10)
     coderay (1.1.0)
     diff-lcs (1.2.5)
     dotenv (2.0.1)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
     method_source (0.8.2)
     mono_logger (1.1.0)
     multi_json (1.11.0)
+    multipart-post (2.0.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -25,6 +29,9 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
+    resque-sentry (1.2.0)
+      resque (>= 1.18.0)
+      sentry-raven (>= 0.4.6)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
       rspec-expectations (~> 3.2.0)
@@ -38,6 +45,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
+    sentry-raven (0.14.0)
+      certifi
+      faraday (>= 0.7.6)
     sinatra (1.4.5)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -56,7 +66,9 @@ DEPENDENCIES
   pry
   rake
   resque
+  resque-sentry
   rspec
+  sentry-raven
 
 BUNDLED WITH
    1.10.6

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,0 +1,24 @@
+require "sentry-raven"
+
+Raven.configure do |config|
+  config.dsn = ENV.fetch("SENTRY_DSN")
+  config.environments = ["staging", "production"]
+  config.current_environment = ENV.fetch("RACK_ENV")
+end
+
+module Raven
+  class Client
+    alias_method :original_send_event, :send_event
+    def send_event(event)
+      unless configuration.send_in_current_environment?
+        log_event_details(event)
+      end
+
+      original_send_event(event)
+    end
+
+    def log_event_details(event)
+      Raven.logger.debug("Caught Exception Event: #{event.message}")
+    end
+  end
+end

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,0 +1,12 @@
+require "resque/failure/multiple"
+require "resque/failure/redis"
+require "resque-sentry"
+
+Resque::Failure::Sentry.logger = "resque"
+
+Resque::Failure::Multiple.classes = [
+  Resque::Failure::Redis,
+  Resque::Failure::Sentry,
+]
+
+Resque::Failure.backend = Resque::Failure::Multiple

--- a/lib/jobs/swift_review_job.rb
+++ b/lib/jobs/swift_review_job.rb
@@ -25,9 +25,6 @@ class SwiftReviewJob
       attributes: attributes,
       violations: violations,
     )
-  rescue => error
-    ap error
-    ap error.backtrace
   end
 
   def self.completed_file_review(file:, attributes:, violations:)


### PR DESCRIPTION
This adds sentry and wires it up to Resque
so that errors get tracked.

I also reopened the Raven::Client to add
logging when we aren't sending the errors
so we can see them happening in development.