### PR TITLE
Add support for SwiftLint config

### DIFF
--- a/bin/hound-swiftlint
+++ b/bin/hound-swiftlint
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Usage:
+# $ bin/hound-swiftlint "swiftlint config yml" "file to lint content"
+
+set -e
+
+temp_config=/tmp/swiftlint_config
+yaml_config="$1"
+file_name="$2"
+file_content="$3"
+file_path=/tmp/$file_name
+
+rm -rf "$temp_config"
+rm -rf "$file_path"
+printf "$yaml_config" > "$temp_config"
+printf "$file_content" > "$file_path"
+swiftlint_output="$(swiftlint lint --path $file_path --config $temp_config)"
+rm -rf "$temp_config"
+rm -rf "$file_path"
+echo "$swiftlint_output"

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,0 +1,5 @@
+disabled_rules:
+included:
+excluded:
+  - Carthage
+  - Pods

--- a/lib/config_options.rb
+++ b/lib/config_options.rb
@@ -1,0 +1,25 @@
+require "yaml"
+
+class ConfigOptions
+  DEFAULT_CONFIG_FILE = "config/default.yml"
+
+  def initialize(config)
+    @custom_options = YAML.load(config.to_s) || {}
+  end
+
+  def to_yaml
+    to_hash.to_yaml
+  end
+
+  def to_hash
+    default_options.merge(custom_options)
+  end
+
+  private
+
+  attr_reader :custom_options
+
+  def default_options
+    @default_config ||= YAML.load_file(DEFAULT_CONFIG_FILE)
+  end
+end

--- a/lib/jobs/swift_review_job.rb
+++ b/lib/jobs/swift_review_job.rb
@@ -1,6 +1,7 @@
 require "resque"
 require "awesome_print"
 
+require "config_options"
 require "jobs/completed_file_review_job"
 require "swift_lint"
 require "swift_lint/file"
@@ -17,8 +18,9 @@ class SwiftReviewJob
     # content
     # config
 
+    config = config_for(attributes: attributes)
     file = file_for(attributes: attributes)
-    violations = violations_for(file: file)
+    violations = violations_for(file: file, config: config)
 
     completed_file_review(
       file: file,
@@ -38,8 +40,8 @@ class SwiftReviewJob
     )
   end
 
-  def self.violations_for(file:)
-    swift_lint_runner = SwiftLint::Runner.new
+  def self.violations_for(file:, config:)
+    swift_lint_runner = SwiftLint::Runner.new(config)
     swift_lint_runner.violations_for(file)
   end
 
@@ -48,5 +50,9 @@ class SwiftReviewJob
       attributes.fetch("filename"),
       attributes.fetch("content"),
     )
+  end
+
+  def self.config_for(attributes:)
+    ConfigOptions.new(attributes["config"])
   end
 end

--- a/lib/swift_lint/runner.rb
+++ b/lib/swift_lint/runner.rb
@@ -1,18 +1,38 @@
 require "swift_lint/violation"
+require "swift_lint/system_call"
 
 module SwiftLint
   class Runner
+    def initialize(config, system_call: SystemCall.new)
+      @config = config
+      @system_call = system_call
+    end
+
     def violations_for(file)
-      violation_strings = execute_swiftlint(file.content).split("\n")
-      violation_strings.map do |violation_string|
+      violation_strings(file).map do |violation_string|
         Violation.new(violation_string).to_hash
       end
     end
 
     private
 
-    def execute_swiftlint(content)
-      `printf '#{content}' | swiftlint lint --use-stdin`
+    attr_reader :config, :system_call
+
+    def violation_strings(file)
+      result = execute_swiftlint(file).split("\n")
+      result.select { |string| message_parsable?(string) }
+    end
+
+    def execute_swiftlint(file)
+      cmd = "bin/hound-swiftlint " \
+        "\"#{config.to_yaml}\" " \
+        "\"#{file.name}\" " \
+        "\"#{file.content}\""
+      system_call.call(cmd)
+    end
+
+    def message_parsable?(string)
+      SwiftLint::Violation.parsable?(string)
     end
   end
 end

--- a/lib/swift_lint/system_call.rb
+++ b/lib/swift_lint/system_call.rb
@@ -1,0 +1,7 @@
+module SwiftLint
+  class SystemCall
+    def call(cmd)
+      `#{cmd}`
+    end
+  end
+end

--- a/lib/swift_lint/violation.rb
+++ b/lib/swift_lint/violation.rb
@@ -1,7 +1,16 @@
 module SwiftLint
   class Violation
-    LINE_NUMBER_REGEX = /<nopath>:(\d+)/
-    MESSAGE_REGEX = /(?:warning|error):\s?(.+)/
+    CLANG_REGEX = /\A
+      .+:                   # File name
+      (\d+):                # Line number
+      (?:\d+:)?\s           # Column Number
+      (?:warning|error):\s  # Type of message
+      (.+)                  # Message
+    \z/x
+
+    def self.parsable?(string)
+      !!(string =~ CLANG_REGEX)
+    end
 
     def initialize(violation_string)
       @violation = violation_string
@@ -15,15 +24,31 @@ module SwiftLint
     end
 
     def line_number
-      LINE_NUMBER_REGEX.match(violation)[1].to_i
+      parts[:line_number].to_i
     end
 
     def message
-      MESSAGE_REGEX.match(violation)[1] || ""
+      parts[:message]
     end
 
     private
 
+    def parts
+      matches = CLANG_REGEX.match(violation)
+
+      if !matches || matches.length < 3
+        raise ViolationParseError, %(Violation: "#{violation}")
+      end
+
+      {
+        line_number: matches[1],
+        message: matches[2],
+      }
+    end
+
     attr_reader :violation
+  end
+
+  class ViolationParseError < StandardError
   end
 end

--- a/spec/jobs/swift_review_job_spec.rb
+++ b/spec/jobs/swift_review_job_spec.rb
@@ -4,7 +4,8 @@ require "jobs/swift_review_job"
 describe SwiftReviewJob do
   describe ".perform" do
     it "enqueues review job with violations" do
-      runner = SwiftLint::Runner.new
+      config = ConfigOptions.new("")
+      runner = SwiftLint::Runner.new(config)
       allow(Resque).to receive(:enqueue)
       allow(SwiftLint::Runner).to receive(:new).and_return(runner)
       allow(runner).
@@ -25,13 +26,20 @@ describe SwiftReviewJob do
         pull_request_number: "123",
         patch: "test",
         violations: [
-          { line: 1, message: "Trailing Whitespace Violation (Medium Severity): Line #1 should have no trailing whitespace: current has 1 trailing whitespace characters" }
+          { line: 1, message: whitespace_violation_message },
         ]
       )
     end
 
+    def whitespace_violation_message
+      "Trailing Whitespace Violation (Medium Severity): " \
+        "Line #1 should have no trailing whitespace: " \
+        "current has 1 trailing whitespace characters"
+    end
+
     def swiftlint_response
-      "<nopath>:1: warning: " \
+      "Loading configuration from /tmp/hound_swiftlint_config\n" \
+        "<nopath>:1: warning: " \
         "Trailing Whitespace Violation (Medium Severity): " \
         "Line #1 should have no trailing whitespace: " \
         "current has 1 trailing whitespace characters\n"

--- a/spec/lib/swift_lint/runner_spec.rb
+++ b/spec/lib/swift_lint/runner_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+require "config_options"
+require "swift_lint/runner"
+require "swift_lint/file"
+
+describe SwiftLint::Runner do
+  describe "#violations_for" do
+    it "executes proper system command to get violations"do
+      config = ConfigOptions.new("")
+      file = SwiftLint::File.new("file.swift", "let x = 1")
+      system_call = SwiftLint::SystemCall.new
+      allow(system_call).to receive(:call).and_return("")
+      runner = SwiftLint::Runner.new(config, system_call: system_call)
+
+      runner.violations_for(file)
+
+      args = %("#{config.to_yaml}" "#{file.name}" "#{file.content}")
+      expected_command = "bin/hound-swiftlint #{args}"
+      expect(system_call).to have_received(:call).with(expected_command)
+    end
+  end
+end

--- a/spec/lib/swift_lint/violation_spec.rb
+++ b/spec/lib/swift_lint/violation_spec.rb
@@ -1,0 +1,84 @@
+require "spec_helper"
+require "swift_lint/violation"
+
+describe SwiftLint::Violation do
+  describe ".parsable?" do
+    context "given a valid clang violation" do
+      it "should parse full clang violation" do
+        parsable = SwiftLint::Violation.parsable?(violation_string)
+
+        expect(parsable).to eq(true)
+      end
+
+      it "should parse a clang violation without a column number" do
+        parsable = SwiftLint::Violation.parsable?(
+          violation_string_without_column,
+        )
+
+        expect(parsable).to eq(true)
+      end
+    end
+
+    context "given an invalid violation" do
+      it "should not be able to parse" do
+        parsable = SwiftLint::Violation.parsable?("Invalid string")
+
+        expect(parsable).to eq(false)
+      end
+    end
+  end
+
+  describe "#line_number" do
+    it "returns line number" do
+      violation = SwiftLint::Violation.new(violation_string(line_number: 1))
+
+      expect(violation.line_number).to eq(1)
+    end
+
+    it "raises with an invalid string" do
+      violation = SwiftLint::Violation.new("invalid string")
+
+      expect { violation.line_number }.
+        to raise_error(
+          SwiftLint::ViolationParseError,
+          /Violation: "invalid string"/,
+        )
+    end
+  end
+
+  describe "#message" do
+    it "returns the message" do
+      message = "Trailing Whitespace Violation: It should not have whitespace."
+      violation = SwiftLint::Violation.new(violation_string(message: message))
+
+      expect(violation.message).to eq(message)
+    end
+
+    it "raises with an invalid string" do
+      violation = SwiftLint::Violation.new("invalid string")
+
+      expect { violation.message }.
+        to raise_error(
+          SwiftLint::ViolationParseError,
+          /Violation: "invalid string"/,
+        )
+    end
+  end
+
+  def violation_string(line_number: 1, message: default_violation_message)
+    "/tmp/test.swift:#{line_number}:1: warning: #{message}"
+  end
+
+  def default_violation_message
+    "Trailing Whitespace Violation (Medium Severity): " \
+      "Line #1 should have no trailing whitespace: " \
+      "current has 1 trailing whitespace characters"
+  end
+
+  def violation_string_without_column
+    "/tmp/test.swift:1: warning: " \
+      "Trailing Whitespace Violation (Medium Severity): " \
+      "Line #1 should have no trailing whitespace: " \
+      "current has 1 trailing whitespace characters"
+  end
+end


### PR DESCRIPTION
Why:

* People want to be able to configure SwiftLint to their liking

This change addresses the need by:

* Passing through the user config to Swiftlint
* Creating `bin/hound-swiftlint` that we call to call out
  to the swiftlint binary on the system.
  - This allows us to run multiple shell commands without having
    to type them all out in ruby.
  - It also makes testing easier because we can make simpler assertions.
* Dependency injecting a `SystemCall` so that we can swap it out
  in test and not actually call the system