### PR TITLE
Raise error when linter script fails

### DIFF
--- a/lib/swift_lint/system_call.rb
+++ b/lib/swift_lint/system_call.rb
@@ -1,7 +1,22 @@
 module SwiftLint
   class SystemCall
+    class NonZeroExitStatusError < StandardError; end
+
     def call(cmd)
+      output = run_command(cmd)
+      if last_command_successful?
+        output
+      else
+        raise NonZeroExitStatusError, "Command: '#{cmd}'"
+      end
+    end
+
+    def run_command(cmd)
       `#{cmd}`
+    end
+
+    def last_command_successful?
+      $?.success?
     end
   end
 end

--- a/spec/jobs/swift_review_job_spec.rb
+++ b/spec/jobs/swift_review_job_spec.rb
@@ -3,7 +3,7 @@ require "jobs/swift_review_job"
 
 describe SwiftReviewJob do
   describe ".perform" do
-    it "enqueues review job with violations" do
+    it "enqueues completed file review job with violations" do
       config = ConfigOptions.new("")
       runner = SwiftLint::Runner.new(config)
       allow(Resque).to receive(:enqueue)
@@ -29,6 +29,31 @@ describe SwiftReviewJob do
           { line: 1, message: whitespace_violation_message },
         ]
       )
+    end
+
+    context "linter script fails" do
+      it "does not enqueue a completed file review job" do
+        runner = instance_double(SwiftLint::Runner)
+        allow(runner).to receive(:violations_for).and_raise(
+          SwiftLint::SystemCall::NonZeroExitStatusError,
+        )
+        allow(SwiftLint::Runner).to receive(:new).and_return(runner)
+        allow(Resque).to receive(:enqueue)
+
+        begin
+          SwiftReviewJob.perform(
+            "filename" => "test.swift",
+            "commit_sha" => "123abc",
+            "pull_request_number" => "123",
+            "patch" => "test",
+            "content" => "let number = 1 \n",
+          )
+        rescue SwiftLint::SystemCall::NonZeroExitStatusError
+          # no-op, this is caught by Resque in the real world.
+        ensure
+          expect(Resque).not_to have_received(:enqueue)
+        end
+      end
     end
 
     def whitespace_violation_message

--- a/spec/lib/swift_lint/system_call_spec.rb
+++ b/spec/lib/swift_lint/system_call_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+require "swift_lint/system_call"
+
+describe SwiftLint::SystemCall do
+  context "running valid command" do
+    it "returns the output" do
+      system = SwiftLint::SystemCall.new
+
+      output = system.call("printf 'Hello World!'")
+
+      expect(output).to eq("Hello World!")
+    end
+  end
+
+  context "running an invalid command" do
+    it "raises an error" do
+      system = SwiftLint::SystemCall.new
+
+      expect { system.call("printf") }.
+        to raise_error(
+          SwiftLint::SystemCall::NonZeroExitStatusError,
+          "Command: 'printf'",
+        )
+    end
+  end
+end


### PR DESCRIPTION
Why:

* It was reporting 0 violations found when it failed because the output had no parseable violations

This change addresses the need by:

* Raising a custom error when the script fails