### PR TITLE
Fix hound-swiftlint command failing

### DIFF
--- a/bin/hound-swiftlint
+++ b/bin/hound-swiftlint
@@ -10,11 +10,13 @@ yaml_config="$1"
 file_name="$2"
 file_content="$3"
 file_path=/tmp/$file_name
+file_directory=$(dirname "$file_path")
 
 rm -rf "$temp_config"
 rm -rf "$file_path"
-printf "$yaml_config" > "$temp_config"
-printf "$file_content" > "$file_path"
+mkdir -p "$file_directory"
+printf -- "$yaml_config" > "$temp_config"
+printf -- "$file_content" > "$file_path"
 swiftlint_output="$(swiftlint lint --path $file_path --config $temp_config)"
 rm -rf "$temp_config"
 rm -rf "$file_path"


### PR DESCRIPTION
Why:

* A file path nested in a few directories would cause it to fail
  because the dir didn't exist
  and it couldn't create a file there.
* `printf` was parsing the config with leading `----` improperly
  because it thought it was the format string.
  More info here: http://unix.stackexchange.com/a/22765
* The command has to run successfully to get the violations :)

This change addresses the need by:

* Using `mkdir -p` to verify the directory exists for the file.
* Separating `printf` content with `--` to make sure it doesn't
  try to interpret the content as a format string.