### PR TITLE
Capture STDOUT and STDERR from SystemCalls

### DIFF
--- a/lib/swift_lint/system_call.rb
+++ b/lib/swift_lint/system_call.rb
@@ -1,22 +1,29 @@
+require "open3"
+
 module SwiftLint
   class SystemCall
     class NonZeroExitStatusError < StandardError; end
 
     def call(cmd)
-      output = run_command(cmd)
+      run_command(cmd)
+
       if last_command_successful?
-        output
+        command_output
       else
         raise NonZeroExitStatusError, "Command: '#{cmd}'"
       end
     end
 
+    private
+
+    attr_reader :command_output, :command_status
+
     def run_command(cmd)
-      `#{cmd}`
+      @command_output, @command_status = Open3.capture2e(cmd)
     end
 
     def last_command_successful?
-      $?.success?
+      command_status.success?
     end
   end
 end

--- a/spec/lib/swift_lint/runner_spec.rb
+++ b/spec/lib/swift_lint/runner_spec.rb
@@ -18,5 +18,17 @@ describe SwiftLint::Runner do
       expected_command = "bin/hound-swiftlint #{args}"
       expect(system_call).to have_received(:call).with(expected_command)
     end
+
+    if /darwin/ =~ RUBY_PLATFORM
+      it "returns all violations" do
+        config = ConfigOptions.new("")
+        file = SwiftLint::File.new("file.swift", "let x = 1")
+        runner = SwiftLint::Runner.new(config)
+
+        violations = runner.violations_for(file)
+
+        expect(violations.size).to eq(2)
+      end
+    end
   end
 end

--- a/spec/lib/swift_lint/system_call_spec.rb
+++ b/spec/lib/swift_lint/system_call_spec.rb
@@ -3,12 +3,29 @@ require "swift_lint/system_call"
 
 describe SwiftLint::SystemCall do
   context "running valid command" do
-    it "returns the output" do
+    it "captures stdout" do
       system = SwiftLint::SystemCall.new
 
       output = system.call("printf 'Hello World!'")
 
       expect(output).to eq("Hello World!")
+    end
+
+    it "captures stderr" do
+      system = SwiftLint::SystemCall.new
+
+      output = system.call("printf 'Hello World!' 1>&2")
+
+      expect(output).to eq("Hello World!")
+    end
+
+    it "captures and concats stdout and stderr" do
+      system = SwiftLint::SystemCall.new
+
+      command = "printf 'Hello Stdout!' && printf 'Hello Stderr!' 1>&2"
+      output = system.call(command)
+
+      expect(output).to eq("Hello Stdout!Hello Stderr!")
     end
   end
 


### PR DESCRIPTION
Why:

* SwiftLint now outputs lint errors to STDERR
  and we were previously only capturing STDOUT.
  https://github.com/realm/SwiftLint/pull/119

This change addresses the need by:

* Using `Open3.capture3` to run commands instead of `Kernel.backtick`
* Adding a test that only runs on Darwin to run the actual `swiftlint` script.