### PR TITLE
Add simple log message when linting a file

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -2,5 +2,7 @@ $LOAD_PATH.unshift(".", "lib")
 
 require "config/initializers/dotenv"
 
+$stdout.sync = true
+
 Dir.glob("config/initializers/**/*.rb").each { |file| require file }
 Dir.glob("lib/**/*.rb").each { |file| require file }

--- a/lib/jobs/swift_review_job.rb
+++ b/lib/jobs/swift_review_job.rb
@@ -21,6 +21,7 @@ class SwiftReviewJob
     config = config_for(attributes: attributes)
     file = file_for(attributes: attributes)
     violations = violations_for(file: file, config: config)
+    puts "Found #{violations.size} violation(s) for #{file.name}"
 
     completed_file_review(
       file: file,


### PR DESCRIPTION
Why:

* I'd like to have some insight into when jobs are processed
  for monitoring it.

This change addresses the need by:

* Enabling `$stdout.sync` so foreman will show `puts` output
  https://github.com/ddollar/foreman/wiki/Missing-Output#ruby
* Add log message with how many violations and file name