### PR TITLE
Request to upgrade SwiftLint to 0.8.0 and related fixes

### DIFF
--- a/bin/hound-swiftlint
+++ b/bin/hound-swiftlint
@@ -5,11 +5,13 @@
 
 set -e
 
-temp_config=/tmp/swiftlint_config
+cd /tmp
+
+temp_config=swiftlint_config
 yaml_config="$1"
 file_name="$2"
 file_content="$3"
-file_path=/tmp/$file_name
+file_path=$file_name
 file_directory=$(dirname "$file_path")
 
 rm -rf "$temp_config"

--- a/spec/lib/swift_lint/runner_spec.rb
+++ b/spec/lib/swift_lint/runner_spec.rb
@@ -27,7 +27,7 @@ describe SwiftLint::Runner do
 
         violations = runner.violations_for(file)
 
-        expect(violations.size).to eq(2)
+        expect(violations.size).to eq(5)
       end
 
       describe "file with major violations" do
@@ -61,48 +61,9 @@ public func <*> <T, U>(f: (T -> U)?, a: T?) -> U? {
 
   def swift_major_file_content
     <<-SWIFT
-class LongMethodSpec {
-  override func spec() {
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("long method body")
-    print("41st line!")
+class ShortVariableName {
+  func tooShort(a: Int) {
+    print("I am too short \(a)")
   }
 }
     SWIFT


### PR DESCRIPTION
You'll have to manually upgrade SwiftLint (this was tested against version 0.8.0)
Perhaps its also preferable to no longer build SwiftLint from source but using `brew update && brew install swiftlint` instead.

Then these 2 fixes will be required thanks to the upgraded version of SwiftLint:
- one fix is related to the updated linter finding more issues and some cleanup
- the second fix is needed when executing `swiflint lint --path /tmp/Source/file.swift ...` and your user SwiftLint configuration is the following:
```
included: # paths to include during linting. `--path` is ignored if present. takes precendence over `excluded`.
  - Source
```
avoiding never finding any file to lint:
```
Loading configuration from '/tmp/swiftlint_config'
Linting Swift files at path /tmp/Source/file.swift
No lintable files found at path '/tmp/Source/file.swift'
Found 0 violation(s) for Source/file.swift
Loading configuration from '/tmp/swiftlint_config'
Linting Swift files at path /tmp/Source/file.swift
No lintable files found at path '/tmp/Source/file.swift'
Found 0 violation(s) for Source/file.swift
```

Also see this iOS linting test PR:
[https://github.com/sync/test-hound/pull/2](PR with failures)